### PR TITLE
Fixing some errors in polynomial degree and evaluation domain

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -44,7 +44,7 @@ impl SigningKey {
             ));
         }
         let mut shares = vec![SigningKeyShare::default(); num_shares];
-        let mut polynomial = DensePolyPrimeField::random(threshold, &mut rng);
+        let mut polynomial = DensePolyPrimeField::random(threshold - 1, &mut rng);
         polynomial.0[0] = self.0;
         for (i, share) in shares.iter_mut().enumerate() {
             let sc = polynomial.evaluate(&Scalar::from((i + 1) as u64));
@@ -114,7 +114,7 @@ impl SigningKey {
 
         let quotients = self.get_quotients(&poly, &encrypted_shares);
 
-        let domain_size = (threshold + 1).next_power_of_two();
+        let domain_size = (encryption_keys.len()).next_power_of_two();
         let domain =
             GeneralEvaluationDomain::<Scalar>::new(domain_size).expect("Failed to create domain");
         let aux_domain = GeneralEvaluationDomain::<Scalar>::new(domain_size * 2)


### PR DESCRIPTION
During benchmarking, I ran into some index-out-of-bounds errors when generating hot shares. I believe this was due to the FFT domain for the evaluations (in `generate_register_payloads`) being set based on the threshold (referred to as `t`) instead of the total number of parties (referred to as `n`) -- this is an issue since all `n` parties need to receive an evaluation of the polynomial at its point, not just `t` of them. This caused an  index-out-of-bounds error on line 138 (`payload.proof = opening_proofs[i];`) since not enough proofs were being computed (line 133).

In the process, I also realized that the polynomial degree used for the secret sharing (in `create_shares`) was higher than necessary: for `t` parties to be able to reconstruct, the degree needs to be only `t-1` instead of `t`.